### PR TITLE
WP-29 Support for multi platform in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@
 # This docker file is used to create multiple docker images
 #
 
-FROM golang:latest AS builder
+FROM --platform=$BUILDPLATFORM golang:alpine AS builder
+ARG TARGETOS
+ARG TARGETARCH
 
 LABEL maintainer="Binu Udayakumar"
 
@@ -20,8 +22,8 @@ WORKDIR /build
 ENV GO111MODULE=auto
 
 # Build WatchDog - Watch for Certificate expiry, connectivity, domain expiry
-RUN CGO_ENABLED=0 GOOS=linux go build  -o watchDog cmd/watchdog/main.go
-RUN CGO_ENABLED=0 GOOS=linux go build  -o watchDogServer cmd/watchdogServer/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build  -o watchDog cmd/watchdog/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build  -o watchDogServer cmd/watchdogServer/main.go
 
 FROM gcr.io/distroless/static
 

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@
 REPO=dronasys
 APP_NAME ?= watchdog
 
-BUILD_VER ?= v0.0.1
-DOCKER_HUB_TAG ?= v0.0.1
+BUILD_VER ?= v0.1.44
+DOCKER_HUB_TAG ?= v0.1.44
 
 TAGGED_NAME = $(REPO)/$(APP_NAME)
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ watchdog --file [PATH-TO-FILE]/config.yaml
 
 * server mode
 ```
-watchdogServer -v -grpc_port 10090 -http_port 10080 --file config.yaml
+watchdogServer -v -grpc_port 10090 -http_port 10080 --file config.yamlgit 
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ watchdog --file [PATH-TO-FILE]/config.yaml
 
 * server mode
 ```
-watchdogServer -v -grpc_port 10090 -http_port 10080 --file config.yamlgit 
+watchdogServer -v -grpc_port 10090 -http_port 10080 --file config.yaml
 ```
 
 


### PR DESCRIPTION
Docker build was only supporting the platform of the build environment. To allow image to be used in both arm and and platform, multiple platform build is enabled.

The GO builder also uses a separate arch and platform when building, this is achieved by passing the build arg as parameter to the docker file. 